### PR TITLE
Remove comment that prevented compilation.

### DIFF
--- a/code/dbdb/binary_tree.py
+++ b/code/dbdb/binary_tree.py
@@ -87,7 +87,6 @@ class BinaryTree(LogicalBase):
         if node is None:
             new_node = BinaryNode(
                 self.node_ref_class(), key, value_ref, self.node_ref_class(), 1) 
-                #comment 因为是一棵新树,所以它的左右分支两个self.node_ref_class()初始化时没有参数.
         elif key < node.key:
             new_node = BinaryNode.from_node(
                 node,


### PR DESCRIPTION
Hey dujiacheng,

I removed this commented line that was preventing compilation on my computer. 
The error I was getting was `SyntaxError: Non-ASCII character '\xe5' in file dbdb/binary_tree.py on line 90, but no encoding declared;`